### PR TITLE
fix alias font rendering during demo playback

### DIFF
--- a/src/Analyse/Render/PlayerSpec.css
+++ b/src/Analyse/Render/PlayerSpec.css
@@ -18,7 +18,7 @@
   height: 42px;
   width: 200px;
   position: relative;
-  font-family: "sans-serif";
+  font-family: sans-serif;
   margin-bottom: 2px;
   user-select: none;
 


### PR DESCRIPTION
sans-serif should be unquoted unless using a font named "sans-serif".