### PR TITLE
Change minimum required player search length from three chars to two

### DIFF
--- a/src/Providers/PlayerProvider.ts
+++ b/src/Providers/PlayerProvider.ts
@@ -6,7 +6,7 @@ export class PlayerProvider extends BaseProvider {
 	static userMap = new Map<SteamId, SteamUser>();
 
 	async search(query: string): Promise<SteamUser[]> {
-		if (query.length <= 2) {
+		if (query.length < 2) {
 			return [];
 		}
 		const users = await this.request('users/search', {query}) as SteamUser[];

--- a/src/Providers/PlayerProvider.tsx
+++ b/src/Providers/PlayerProvider.tsx
@@ -6,7 +6,7 @@ export class PlayerProvider extends BaseProvider {
 	static userMap = new Map<SteamId, SteamUser>();
 
 	async search(query: string): Promise<SteamUser[]> {
-		if (query.length <= 2) {
+		if (query.length < 2) {
 			return [];
 		}
 		const users = await this.request('users/search', {query}) as SteamUser[];


### PR DESCRIPTION
Lowers the minimum amount of chars to find valid results for a given player to two characters.
This makes it possible to find people with two letter names e.g. `Bv`