### PR TITLE
Fixed occurences of text overflow and some low contrast text

### DIFF
--- a/src/Components/ChatTable.css
+++ b/src/Components/ChatTable.css
@@ -1,10 +1,4 @@
 table.chat {
-  td.duration {
-    width: 80px;
-    text-align: right;
-    color: var(--text-secondary);
-  }
-
   td.user {
     white-space: nowrap;
     vertical-align: top;
@@ -12,5 +6,15 @@ table.chat {
     color: var(--text-secondary);
     text-align: right;
     border-right: 1px solid #ccc
+  }
+
+  td.message {
+    word-break: break-all;
+  }
+
+  td.duration {
+    width: 80px;
+    text-align: right;
+    color: var(--text-secondary);
   }
 }

--- a/src/Components/FilterBar.tsx
+++ b/src/Components/FilterBar.tsx
@@ -117,6 +117,10 @@ export class FilterBar extends React.Component<FilterBarProps, FilterBarState> {
 						option: (styles, { isFocused, isSelected }) => ({
 							...styles,
 							backgroundColor: isSelected ? 'var(--highlight-primary)' : isFocused ? 'var(--highlight-secondary)' : undefined
+						}),
+						input: (base) => ({
+							...base,
+							color: 'var(--text-primary)'
 						})
 					}}
 				/>
@@ -135,6 +139,10 @@ export class FilterBar extends React.Component<FilterBarProps, FilterBarState> {
 						option: (styles, { isFocused, isSelected }) => ({
 							...styles,
 							backgroundColor: isSelected ? 'var(--highlight-primary)' : isFocused ? 'var(--highlight-secondary)' : undefined
+						}),
+						input: (base) => ({
+							...base,
+							color: 'var(--text-primary)'
 						})
 					}}
 				/>
@@ -160,6 +168,10 @@ export class FilterBar extends React.Component<FilterBarProps, FilterBarState> {
 						option: (styles, { isFocused, isSelected }) => ({
 							...styles,
 							backgroundColor: isSelected ? 'var(--highlight-primary)' : isFocused ? 'var(--highlight-secondary)' : undefined
+						}),
+						input: (base) => ({
+							...base,
+							color: 'var(--text-primary)'
 						})
 					}}
 				/>

--- a/src/Pages/ListPage.css
+++ b/src/Pages/ListPage.css
@@ -21,6 +21,10 @@
 		margin: 0;
 	}
 
+	td.title {
+		max-width: 0px;
+	}
+
 	td.date {
 		width: 120px;
 	}


### PR DESCRIPTION
This fixes the text color when searching for specific players barely being visible, as well as really long chat messages or titles making the table expand beyond it's parent div