### PR TITLE
Fix for Dockerfile smell DL4006

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apk add --no-cache --virtual .build-deps \
   brotli-dev
 
 # Reuse same cli arguments as the nginx:alpine image used to build
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
   tar -zxf nginx.tar.gz && \
   tar -xzf "${NGX_MODULE_PATH}.tar.gz" && \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation (smell) [DL4006](https://github.com/hadolint/hadolint/wiki/DL4006) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL4006 occurs when there is a RUN instruction with a pipe in and the `-o pipefail` option is missing. The issue is that the RUN instruction only evaluates the exit code of the last operation in the pipe to determine success. Thus, during the Docker build, if one of the statements contained in the RUN instruction fails but not the last, the build will continue even if there is an error.
This pull request proposes a fix generated by a fixing tool that I developed to fix this kind of smell. The patch was manually verified before opening the pull request. To fix this smell, specifically, the option `-o pipefail` is placed before the RUN instruction with a pipe in.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
